### PR TITLE
Update xprof.sql

### DIFF
--- a/xprof.sql
+++ b/xprof.sql
@@ -9,7 +9,8 @@ SELECT
 	DBMS_SQLTUNE.REPORT_SQL_MONITOR(   
 	   &3=>&4,   
 	   report_level=>'&1',
-	   type => '&2') as report   
+	   type => '&2'
+	   inst_id => -1) as report
 FROM dual
 /
 


### PR DESCRIPTION
I recently had a problem that xp.sql was looking for sessions from another instance.

Added parameter: inst_id => -1

Documentation: Looks only at queries started on the specified instance. Use -1 to target the current instance. The default, NULL will target all instances.
Link: https://docs.oracle.com/database/121/ARPLS/d_sql_monitor.htm#ARPLS74789