### PR TITLE
add a script to generate an optimizer trace from the cursor cache

### DIFF
--- a/53trace.sql
+++ b/53trace.sql
@@ -1,0 +1,41 @@
+/*   
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   Purpose:
+
+   generate an optimizer trace from the cursor cache. Removes the need to 
+   purge the cursor or force a hard parse
+*/
+
+PRO 
+PRO Generate an optimizer trace from the cursor cache
+PRO
+
+ACC v_sql_id PROMPT 'Enter your SQL ID: '
+
+PRO checking cursor cache for SQL ID &v_sql_id
+
+select sql_id, plan_hash_value, child_number from gv$sql where sql_id = '&v_sql_id';
+
+ACC v_child_number PROMPT 'Enter the child cursor number: '
+
+BEGIN
+    sys.DBMS_SQLDIAG.DUMP_TRACE(
+        p_sql_id => '&v_sql_id',
+        p_child_number => &v_child_number,
+        p_component => 'Compiler'
+    );
+END;
+/
+
+select 'Trace file: ' || value tracefile from v$diag_info where name like 'Def%';


### PR DESCRIPTION
# Why this change
There is currently no script in the `tpt` suite allowing the creation of an optimizer trace from the cursor cache. As explained in [this blog post by Maria Colgan](https://blogs.oracle.com/optimizer/post/capturing-10053-trace-files-continued) it is possible to generate a `10053` trace without the need of a new hard parse. This might be useful in some situations where a hard parse can lead to bad performance.
# What is changing
A new script, 53trace.sql has been added.